### PR TITLE
Bugfix #185 Aterando ordem em que o evento pegava os ids

### DIFF
--- a/front-end/pret-event/src/app/screens/new-event/new-event.component.ts
+++ b/front-end/pret-event/src/app/screens/new-event/new-event.component.ts
@@ -58,8 +58,8 @@ export class NewEventComponent implements OnInit {
       this.eventForm.get('time').value,
       0,
       this.eventForm.get('description').value,
-      this.currentId,
       reward.id,
+      this.currentId
     );
     this.service.registerEvent(event, this.file).then(x => {
       console.log(x);


### PR DESCRIPTION
[BUG] - Eventos sendo cadastrados com Id errado

## Descrição
Ao criar um Evento com um novo usuario dentro de um banco de dados limpo, o evento está sendo criado com o id de usuario errado.

## Critérios
- [x] Build passando.
- [x] Sem conflitos com a Branch Base.

Resolve #185 