### PR TITLE
T73 - Validar campo data na criação de evento

### DIFF
--- a/front-end/pret-event/src/app/screens/new-event/new-event.component.ts
+++ b/front-end/pret-event/src/app/screens/new-event/new-event.component.ts
@@ -49,7 +49,7 @@ export class NewEventComponent implements OnInit {
   registerEvent() {
     this.clicked = true;
     const reward = this.rewards.find(r => r.title === this.selected);
-    console.log(this.eventForm.get('time').value);
+    console.log(formatDate(Date.now(), 'HH:mm', 'en-US'));
     if (!reward) {
       this.data.addAlert(new Alert('danger', 'Recompensa inválida!', 3000));
       this.clicked = false;
@@ -66,12 +66,12 @@ export class NewEventComponent implements OnInit {
       return;
     }
     else if (this.eventForm.get('date').value < formatDate(Date.now(), 'yyyy-MM-dd', 'en-US')) {
-      this.data.addAlert(new Alert('danger', 'Data passou!', 3000));
+      this.data.addAlert(new Alert('danger', 'Data inválida!', 3000));
       this.clicked = false;
       return;
     }
-    else if (this.eventForm.get('date').value == formatDate(Date.now(), 'yyyy-MM-dd', 'en-US') && this.eventForm.get('time').value < formatDate(Date.now(), 'hh:mm', 'en-US')) {
-      this.data.addAlert(new Alert('danger', 'Hora passou!', 3000));
+    else if (this.eventForm.get('date').value == formatDate(Date.now(), 'yyyy-MM-dd', 'en-US') && this.eventForm.get('time').value < formatDate(Date.now(), 'HH:mm', 'en-US')) {
+      this.data.addAlert(new Alert('danger', 'Hora inválida!', 3000));
       this.clicked = false;
       return;
     }

--- a/front-end/pret-event/src/app/screens/new-event/new-event.component.ts
+++ b/front-end/pret-event/src/app/screens/new-event/new-event.component.ts
@@ -8,9 +8,9 @@ import { Alert } from '../../models/alert';
 import { EventService } from '../../services/event.service';
 import { RewardService } from '../../services/reward.service';
 import { AlertService } from 'src/app/services/alert.service';
-import { PlayerService } from '../../services/player.service';
 import { getId } from 'src/app/helpers/id';
 import { validateEvent } from '../../../helpers/validators';
+import { formatDate } from '@angular/common';
 
 @Component({
   selector: 'app-new-event',
@@ -49,6 +49,7 @@ export class NewEventComponent implements OnInit {
   registerEvent() {
     this.clicked = true;
     const reward = this.rewards.find(r => r.title === this.selected);
+    console.log(this.eventForm.get('time').value);
     if (!reward) {
       this.data.addAlert(new Alert('danger', 'Recompensa inválida!', 3000));
       this.clicked = false;
@@ -56,6 +57,21 @@ export class NewEventComponent implements OnInit {
     }
     if (this.eventForm.get('time').value === '') {
       this.data.addAlert(new Alert('danger', 'Hora inválida!', 3000));
+      this.clicked = false;
+      return;
+    }
+    if (this.eventForm.get('date').value == '') {
+      this.data.addAlert(new Alert('danger', 'Data inválida!', 3000));
+      this.clicked = false;
+      return;
+    }
+    else if (this.eventForm.get('date').value < formatDate(Date.now(), 'yyyy-MM-dd', 'en-US')) {
+      this.data.addAlert(new Alert('danger', 'Data passou!', 3000));
+      this.clicked = false;
+      return;
+    }
+    else if (this.eventForm.get('date').value == formatDate(Date.now(), 'yyyy-MM-dd', 'en-US') && this.eventForm.get('time').value < formatDate(Date.now(), 'hh:mm', 'en-US')) {
+      this.data.addAlert(new Alert('danger', 'Hora passou!', 3000));
       this.clicked = false;
       return;
     }


### PR DESCRIPTION
## Descrição
Alerta usuário quando a data/hora inserida na criação de evento é inválida.

## Porque este Pull Request é necessário?
Impede a criação de eventos com datas/horas que já passaram.

## Critérios
- [x] Não deve ser possível criar evento com uma data que já passou.
- [x] Mostrar obrigatoriedade do campo usando elementos do bootstrap.
- [x] Botão de enviar deverá ficar desabilitado até que o formulário esteja validado.

Resolve #191 